### PR TITLE
Force missing of directly adjacent (horiz/vertic) targets.

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -96,8 +96,8 @@
 				if (daddy.target && original in daddy.target) //As opposed to no-delay pew pew
 					miss_modifier += -30
 			def_zone = get_zone_with_miss_chance(def_zone, M, -30 + 8*distance)
-
-			if(!def_zone)
+			
+			if(!def_zone || get_adj_simple(firer,A))
 				visible_message("\blue \The [src] misses [M] narrowly!")
 				forcedodge = -1
 			else
@@ -203,3 +203,15 @@
 				M = locate() in get_step(src,target)
 				if(istype(M))
 					return 1
+
+//Abby -- Just check if they're 1 tile horizontal or vertical, no diagonals
+/proc/get_adj_simple(atom/Loc1 as turf|mob|obj,atom/Loc2 as turf|mob|obj)
+	var/dx = Loc1.x - Loc2.x
+	var/dy = Loc1.y - Loc2.y
+	if(dx == 0)
+		if(dy == -1 || dy == 1)
+			return 1
+	if(dy == 0)
+		if(dx == -1 || dx == 1)
+			return 1
+	return 0

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -96,7 +96,7 @@
 				if (daddy.target && original in daddy.target) //As opposed to no-delay pew pew
 					miss_modifier += -30
 			def_zone = get_zone_with_miss_chance(def_zone, M, -30 + 8*distance)
-			
+
 			if(!def_zone || get_adj_simple(firer,A))
 				visible_message("\blue \The [src] misses [M] narrowly!")
 				forcedodge = -1
@@ -208,10 +208,12 @@
 /proc/get_adj_simple(atom/Loc1 as turf|mob|obj,atom/Loc2 as turf|mob|obj)
 	var/dx = Loc1.x - Loc2.x
 	var/dy = Loc1.y - Loc2.y
+
 	if(dx == 0)
 		if(dy == -1 || dy == 1)
 			return 1
 	if(dy == 0)
 		if(dx == -1 || dx == 1)
 			return 1
+
 	return 0

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -41,14 +41,17 @@ should be listed in the changelog upon commit tho. Thanks. -->
 
 <!-- DO NOT REMOVE OR MOVE THIS COMMENT! THIS MUST BE THE LAST NON-EMPTY LINE BEFORE THE LOGS #ADDTOCHANGELOGMARKER# -->
 
+
 <div class='commit sansserif'>
-	<h2 class='date'>13 May 2015</h2>
-	<h3 class='author'>Apophis775 updated:</h3>
+	<h2 class='date'>14 May 2015</h2>
+	<h3 class='author'>Absynth updated:</h3>
 	<ul class='changes bgimages16'>
-		<li class='rscdel'>RCD removed from Hacked Autolathe</li>
-		<li class='imageadd'>Donor Items - Reply to your forum post if there are any issues.</li>
+		<li class='bugfix'>Flamethrowers recoded to work without having to use atmos or gasses.</li>
+		<li class='bugfix'>Bullets no longer hit directly (horizontal/vertical) targets. You can still point blank shot by clicking.</li>
 	</ul>
 </div>
+
+
 
 <div class='commit sansserif'>
   <h2 class='date'>11 May 2015</h2>


### PR DESCRIPTION
Adds a simple function to check for direct adjacents, since one doesn't actually exist, to avoid problems in friendly fire due to shitty projectile pathfinding. Also means it will miss people directly in front of you, but ehhh. Up close you should have to click anyway for a point blank shot.
