### PR TITLE
Mounted flashlights and adjacent friendly fire

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/lighting.dmi'
 	icon_state = "flashlight"
 	item_state = "flashlight"
-	w_class = 2
+	w_class = 3
 	flags = FPRINT | TABLEPASS | CONDUCT
 	slot_flags = SLOT_BELT
 	m_amt = 50
@@ -153,7 +153,7 @@
 /obj/item/device/flashlight/flare
 	name = "flare"
 	desc = "A red Nanotrasen issued flare. There are instructions on the side, it reads 'pull cord, make light'."
-	w_class = 2.0
+	w_class = 3
 	brightness_on = 7 // Pretty bright.
 	icon_state = "flare"
 	item_state = "flare"

--- a/code/game/objects/items/weapons/flamethrower.dm
+++ b/code/game/objects/items/weapons/flamethrower.dm
@@ -229,6 +229,7 @@
 	var/turf/simulated/T = loc
 
 	if (!istype(T)) //Is it a valid turf? Has to be simulated and on a floor
+		processing_objects.Remove(src)
 		del(src)
 		return
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -32,6 +32,10 @@
 						//1 for keep shooting until aim is lowered
 	var/fire_delay = 6
 	var/last_fired = 0
+		//flashlight stuff
+	var/haslight = 0 //Is there a flashlight attached?
+	var/islighton = 0
+	var/gun_light = 5 //How bright will the light be?
 
 	proc/ready_to_fire()
 		if(world.time >= last_fired + fire_delay)
@@ -220,3 +224,25 @@
 			return
 	else
 		return ..() //Pistolwhippin'
+
+/obj/item/weapon/gun/verb/toggle_light()
+	set name = "Toggle Weapon Light"
+	set category = "Object"
+
+	if(!haslight)
+		usr << "There's no flashlight attached. Use a screwdriver on a flashlight to attach one."
+		return
+	if(islighton)
+		playsound(usr, 'sound/weapons/empty.ogg', 100, 1)
+		islighton = 0
+		if(loc == usr)
+			usr.SetLuminosity(usr.luminosity - gun_light)
+		else
+			SetLuminosity(gun_light)
+	else
+		islighton = 1
+		playsound(usr, 'sound/weapons/empty.ogg', 100, 1)
+		if(loc == usr)
+			usr.SetLuminosity(usr.luminosity + gun_light)
+		else
+			SetLuminosity(0)

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -17,7 +17,6 @@
 	var/load_method = SPEEDLOADER //0 = Single shells or quick loader, 1 = box, 2 = magazine
 	var/obj/item/ammo_magazine/empty_mag = null
 
-
 /obj/item/weapon/gun/projectile/New()
 	..()
 	for(var/i = 1, i <= max_shells, i++)
@@ -49,6 +48,21 @@
 /obj/item/weapon/gun/projectile/attackby(var/obj/item/A as obj, mob/user as mob)
 	var/obj/item/ammo_magazine/AM = A
 	var/num_loaded = 0
+	if(istype(A, /obj/item/device/flashlight))
+		if(!istype(src,/obj/item/weapon/gun/projectile)) //Add gun types here to make them gun-specific
+			user << "It doesn't fit."
+			return
+		if(haslight)
+			user << "It's already got a flashlight."
+			return
+		if(A:attachable)
+			user << "\red You attach [A] to [src]. Use 'toggle weapon light' in the Object tab to turn it on."
+			haslight = 1
+			del(A)
+			return
+		else
+			user << "Use a screwdriver to modify the flashlight first."
+			return
 	if(istype(A, /obj/item/ammo_magazine))
 		if((load_method == MAGAZINE) && loaded.len)	return
 		for(var/obj/item/ammo_casing/AC in AM.stored_ammo)
@@ -122,16 +136,14 @@
 			bullets += 1
 	return bullets
 
+/obj/item/weapon/gun/projectile/dropped(mob/user as mob)
+	if(haslight && islighton) //Transfer light to the gun
+		user.SetLuminosity(user.luminosity - gun_light)
+		SetLuminosity(gun_light)
+	return
 
-//FLASHLIGHT CODE FOR M39 APOPHIS775 31JAN2015
-
-/obj/item/weapon/gun/projectile/automatic/Assault/attackby(var/obj/item/A as obj, mob/user as mob)
-	..()
-	if(istype(A, /obj/item/device/flashlight))
-		var/obj/item/device/flashlight/F = A
-		if(F.attachable)
-			src.contents += A
-			user << "\red You attach [A] to [src]."
-			haslight = 1
-			del(A)
+/obj/item/weapon/gun/projectile/pickup(mob/user)
+	if(haslight && islighton) //Transfer light to the mob
+		user.SetLuminosity(user.luminosity + gun_light)
+		SetLuminosity(0)
 	return

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -126,16 +126,17 @@
 
 
 /obj/item/weapon/gun/projectile/twohanded/automatic/l6_saw/attackby(var/obj/item/A as obj, mob/user as mob)
-	if(!cover_open)
-		user << "<span class='notice'>[src]'s cover is closed! You can't insert a new mag!</span>"
-		return
-	else if(cover_open && mag_inserted)
-		user << "<span class='notice'>[src] already has a magazine inserted!</span>"
-		return
-	else if(cover_open && !mag_inserted)
-		mag_inserted = 1
-		user << "<span class='notice'>You insert the magazine!</span>"
-		update_icon()
+	if(istype(A,/obj/item/ammo_magazine/a762))
+		if(!cover_open)
+			user << "<span class='notice'>[src]'s cover is closed! You can't insert a new mag!</span>"
+			return
+		else if(cover_open && mag_inserted)
+			user << "<span class='notice'>[src] already has a magazine inserted!</span>"
+			return
+		else if(cover_open && !mag_inserted)
+			mag_inserted = 1
+			user << "<span class='notice'>You insert the magazine!</span>"
+			update_icon()
 	..()
 
 
@@ -148,38 +149,37 @@
 
 
 //FLASHLIGHT CODE FOR M39 SMG APOPHIS775 - 31JAN2015
+//Moved to guns/projectile.dm and twohanded_projectile
 
-/obj/item/weapon/gun/projectile/automatic/Assault
-	//flashlight stuff
-	var/haslight = 0 //Is there a flashlight attached?
-	var/islighton = 0
-	var/gun_light = 5 //How bright will the light be?
+///obj/item/weapon/gun/projectile/automatic/Assault
+//	//flashlight stuff
+//	var/haslight = 0 //Is there a flashlight attached?
+//	var/islighton = 0
+//	var/gun_light = 5 //How bright will the light be?
+//
+//
+///obj/item/weapon/gun/projectile/automatic/Assault/verb/toggle_light()
+//	set name = "Toggle Flashlight"
+//	set category = "Weapon"
+//
+//	if(haslight && !islighton) //Turns the light on
+//		usr << "\blue You turn the flashlight on."
+//		usr.SetLuminosity(gun_light)
+//		islighton = 1
+//	else if(haslight && islighton) //Turns the light off
+//		usr << "\blue You turn the flashlight off."
+//		usr.SetLuminosity(0)
+//		islighton = 0
+//	else if(!haslight) //Points out how stupid you are
+//		usr << "\red You foolishly look at where the flashlight would be, if it was attached..."
+//
+///obj/item/weapon/gun/projectile/automatic/Assault/pickup(mob/user)//Transfers the lum to the user when picked up
+//	if(islighton)
+//		SetLuminosity(0)
+//		usr.SetLuminosity(gun_light)
 
-
-/obj/item/weapon/gun/projectile/automatic/Assault/verb/toggle_light()
-	set name = "Toggle Flashlight"
-	set category = "Weapon"
-
-	if(haslight && !islighton) //Turns the light on
-		usr << "\blue You turn the flashlight on."
-		usr.SetLuminosity(gun_light)
-		islighton = 1
-	else if(haslight && islighton) //Turns the light off
-		usr << "\blue You turn the flashlight off."
-		usr.SetLuminosity(0)
-		islighton = 0
-	else if(!haslight) //Points out how stupid you are
-		usr << "\red You foolishly look at where the flashlight would be, if it was attached..."
-
-/obj/item/weapon/gun/projectile/automatic/Assault/pickup(mob/user)//Transfers the lum to the user when picked up
-	if(islighton)
-		SetLuminosity(0)
-		usr.SetLuminosity(gun_light)
-
-/obj/item/weapon/gun/projectile/automatic/Assault/dropped(mob/user)//Transfers the Lum back to the gun when dropped
-	if(islighton)
-		SetLuminosity(gun_light)
-		usr.SetLuminosity(0)
-
-
+///obj/item/weapon/gun/projectile/automatic/Assault/dropped(mob/user)//Transfers the Lum back to the gun when dropped
+//	if(islighton)
+//		SetLuminosity(gun_light)
+//		usr.SetLuminosity(0)
 

--- a/code/modules/projectiles/guns/twohanded_projectile.dm
+++ b/code/modules/projectiles/guns/twohanded_projectile.dm
@@ -10,13 +10,6 @@
 	var/max_shells = 7
 	var/load_method = SPEEDLOADER //0 = Single shells or quick loader, 1 = box, 2 = magazine
 	var/obj/item/ammo_magazine/empty_mag = null
-
-
-	//flashlight stuff
-	var/haslight = 0 //Is there a flashlight attached?
-	var/islighton = 0
-
-
 	//Bayonet
 	var/hasBayonet = 0 //Is there a bayonet?
 	var/bayonetDamage = 40 //Controls the bayonet Damage
@@ -91,6 +84,21 @@
 
 /obj/item/weapon/gun/twohanded/projectile/attackby(var/obj/item/A as obj, mob/user as mob)
 	var/num_loaded = 0
+	if(istype(A, /obj/item/device/flashlight))
+		if(!istype(src,/obj/item/weapon/gun/twohanded/projectile/)) //Add guns here. Leaving it as all 2handers for now
+			user << "It doesn't fit."
+			return
+		if(haslight)
+			user << "It's already got a flashlight."
+			return
+		if(A:attachable)
+			user << "\red You attach [A] to [src]. Use 'toggle weapon light' in the Object tab to turn it on."
+			haslight = 1
+			del(A)
+			return
+		else
+			user << "Use a screwdriver to modify the flashlight first."
+			return
 	if(istype(A, /obj/item/ammo_magazine))
 		if((load_method == MAGAZINE) && loaded.len)	return
 		var/obj/item/ammo_magazine/AM = A
@@ -260,6 +268,9 @@
 		var/obj/item/weapon/twohanded/projectile/offhand/O = user.get_inactive_hand()
 		if(O && istype(O))
 			O.unwield()
+	if(haslight && islighton) //Transfer light to the gun
+		user.SetLuminosity(user.luminosity - gun_light)
+		SetLuminosity(gun_light)
 	return
 
 /obj/item/weapon/gun/twohanded/projectile/update_icon()
@@ -267,7 +278,17 @@
 
 /obj/item/weapon/gun/twohanded/projectile/pickup(mob/user)
 	unwield()
+	if(haslight && islighton) //Transfer light to the mob
+		user.SetLuminosity(user.luminosity + gun_light)
+		SetLuminosity(0)
 	return
+
+/obj/item/device/flashlight/pickup(mob/user)
+
+
+
+/obj/item/device/flashlight/dropped(mob/user)
+
 
 /obj/item/weapon/gun/twohanded/projectile/attack_self(mob/user as mob)
 	if( istype(user,/mob/living/carbon/monkey) )
@@ -300,15 +321,3 @@
 		O.desc = "Your second grip on the [initial(name)]"
 		user.put_in_inactive_hand(O)
 		return
-
-//NEW RIOT SHOTGUN FLASHLIGHT CODE APOPHIS775 05FEB2015
-/obj/item/weapon/gun/twohanded/projectile/shotgun/pump/attackby(var/obj/item/A as obj, mob/user as mob)
-	..()
-	if(istype(A, /obj/item/device/flashlight))
-		var/obj/item/device/flashlight/F = A
-		if(F.attachable)
-			src.contents += A
-			user << "\red You attach [A] to [src]."
-			haslight = 1
-			del(A)
-	return

--- a/code/modules/projectiles/guns/twohanded_projectile/assault.dm
+++ b/code/modules/projectiles/guns/twohanded_projectile/assault.dm
@@ -11,8 +11,6 @@
 	fire_sound = 'sound/weapons/Gunshot_smg.ogg'
 	load_method = 2
 	fire_delay = 2
-	var/gun_light = 7 // Defines how bright the light on the flashlight will be
-
 
 	New()
 		..()
@@ -40,31 +38,31 @@
 		return
 
 ///////NEW FANCY FLASHLIGHT CODE MADE OF HOPES AND DREAMS./
+//Moved to guns/projectile.dm
 
-
-/obj/item/weapon/gun/twohanded/projectile/Assault/verb/toggle_light()
-	set name = "Toggle Flashlight"
-	set category = "Weapon"
-
-	if(haslight && !islighton) //Turns the light on
-		usr << "\blue You turn the flashlight on."
-		usr.SetLuminosity(gun_light)
-		islighton = 1
-	else if(haslight && islighton) //Turns the light off
-		usr << "\blue You turn the flashlight off."
-		usr.SetLuminosity(0)
-		islighton = 0
-	else if(!haslight) //Points out how stupid you are
-		usr << "\red You foolishly look at where the flashlight would be, if it was attached..."
-
-/obj/item/weapon/gun/twohanded/projectile/Assault/pickup(mob/user)//Transfers the lum to the user when picked up
-	..()
-	if(islighton)
-		SetLuminosity(0)
-		usr.SetLuminosity(gun_light)
-
-/obj/item/weapon/gun/twohanded/projectile/Assault/dropped(mob/user)//Transfers the Lum back to the gun when dropped
-	..()
-	if(islighton)
-		SetLuminosity(gun_light)
-		usr.SetLuminosity(0)
+///obj/item/weapon/gun/twohanded/projectile/Assault/verb/toggle_light()
+//	set name = "Toggle Flashlight"
+//	set category = "Weapon"
+//
+//	if(haslight && !islighton) //Turns the light on
+//		usr << "\blue You turn the flashlight on."
+//		usr.SetLuminosity(gun_light)
+//		islighton = 1
+//	else if(haslight && islighton) //Turns the light off
+//		usr << "\blue You turn the flashlight off."
+//		usr.SetLuminosity(0)
+//		islighton = 0
+//	else if(!haslight) //Points out how stupid you are
+//		usr << "\red You foolishly look at where the flashlight would be, if it was attached..."
+//
+///obj/item/weapon/gun/twohanded/projectile/Assault/pickup(mob/user)//Transfers the lum to the user when picked up
+//	..()
+//	if(islighton)
+//		SetLuminosity(0)
+//		usr.SetLuminosity(gun_light)
+//
+///obj/item/weapon/gun/twohanded/projectile/Assault/dropped(mob/user)//Transfers the Lum back to the gun when dropped
+//	..()
+//	if(islighton)
+//		SetLuminosity(gun_light)
+//		usr.SetLuminosity(0)

--- a/code/modules/projectiles/guns/twohanded_projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/twohanded_projectile/shotgun.dm
@@ -11,25 +11,28 @@
 	caliber = "shotgun"
 	origin_tech = "combat=4;materials=2"
 	ammo_type = "/obj/item/ammo_casing/shotgun/beanbag"
+	var/recentpump = 0 // to prevent spammage
 	var/pumped = 0
 	var/obj/item/ammo_casing/current_shell = null
-	recoil = 4
 
 	isHandgun()
 		return 0
 
-	afterattack(atom/target as mob|obj|turf|area, mob/living/user as mob|obj, flag)
-		..()
-		if(in_chamber) //To stop spamming before pump
-			in_chamber = null
-		sleep(5)
+	load_into_chamber()
+		if(in_chamber)
+			return 1
+		return 0
+
+
+	proc/pump_gun(mob/M as mob)
 		playsound(loc, 'sound/weapons/shotgun_pump.ogg', 60, 1, -1)
-		if(current_shell)
-			current_shell.loc = get_turf(src)
+		pumped = 0
+		if(current_shell)//We have a shell in the chamber
+			current_shell.loc = get_turf(src)//Eject casing
 			current_shell = null
 			if(in_chamber)
 				in_chamber = null
-		if(!loaded.len) return 0 //empty
+		if(!loaded.len)	return 0
 		var/obj/item/ammo_casing/AC = loaded[1] //load next casing.
 		loaded -= AC //Remove casing from loaded list.
 		current_shell = AC
@@ -37,10 +40,19 @@
 			AC.spent = 1
 			in_chamber = AC.BB //Load projectile into chamber.
 		update_icon()	//I.E. fix the desc
+		return 1
+
+/obj/item/weapon/gun/twohanded/projectile/shotgun/pump/verb/pump()
+	set name = "Pump Shotgun"
+	set category = "Weapon"
+
+	if(recentpump)
 		return
 
-/obj/item/weapon/gun/twohanded/projectile/shotgun/pump/load_into_chamber()  //copy over the standard version, chambers itself after attacks
-	return 0
+	pump_gun()
+	recentpump = 1
+	spawn(10)
+		recentpump = 0
 
 /obj/item/weapon/gun/twohanded/projectile/shotgun/pump/combat
 	name = "combat shotgun"
@@ -48,14 +60,13 @@
 	max_shells = 8
 	origin_tech = "combat=5;materials=2"
 	ammo_type = "/obj/item/ammo_casing/shotgun"
-
-
 /obj/item/weapon/gun/twohanded/projectile/shotgun/pump/riot
 	name = "riot shotgun"
 	icon_state = "cshotgun"
 	max_shells = 8
 	origin_tech = "combat=5;materials=2"
 	ammo_type = "/obj/item/ammo_casing/shotgun/beanbag"
+
 
 
 //PUMP SHOTGUN FLASHLIGHT CODE

--- a/code/modules/projectiles/guns/twohanded_projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/twohanded_projectile/shotgun.dm
@@ -14,6 +14,7 @@
 	var/recentpump = 0 // to prevent spammage
 	var/pumped = 0
 	var/obj/item/ammo_casing/current_shell = null
+	recoil = 1
 
 	isHandgun()
 		return 0

--- a/code/modules/projectiles/guns/twohanded_projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/twohanded_projectile/shotgun.dm
@@ -11,30 +11,25 @@
 	caliber = "shotgun"
 	origin_tech = "combat=4;materials=2"
 	ammo_type = "/obj/item/ammo_casing/shotgun/beanbag"
-	var/recentpump = 0 // to prevent spammage
 	var/pumped = 0
 	var/obj/item/ammo_casing/current_shell = null
-	var/gun_light = 6 // Defines how bright the light on the flashlight will be
-
+	recoil = 4
 
 	isHandgun()
 		return 0
 
-	load_into_chamber()
-		if(in_chamber)
-			return 1
-		return 0
-
-
-	proc/pump_gun(mob/M as mob)
+	afterattack(atom/target as mob|obj|turf|area, mob/living/user as mob|obj, flag)
+		..()
+		if(in_chamber) //To stop spamming before pump
+			in_chamber = null
+		sleep(5)
 		playsound(loc, 'sound/weapons/shotgun_pump.ogg', 60, 1, -1)
-		pumped = 0
-		if(current_shell)//We have a shell in the chamber
-			current_shell.loc = get_turf(src)//Eject casing
+		if(current_shell)
+			current_shell.loc = get_turf(src)
 			current_shell = null
 			if(in_chamber)
 				in_chamber = null
-		if(!loaded.len)	return 0
+		if(!loaded.len) return 0 //empty
 		var/obj/item/ammo_casing/AC = loaded[1] //load next casing.
 		loaded -= AC //Remove casing from loaded list.
 		current_shell = AC
@@ -42,19 +37,10 @@
 			AC.spent = 1
 			in_chamber = AC.BB //Load projectile into chamber.
 		update_icon()	//I.E. fix the desc
-		return 1
-
-/obj/item/weapon/gun/twohanded/projectile/shotgun/pump/verb/pump()
-	set name = "Pump Shotgun"
-	set category = "Weapon"
-
-	if(recentpump)
 		return
 
-	pump_gun()
-	recentpump = 1
-	spawn(10)
-		recentpump = 0
+/obj/item/weapon/gun/twohanded/projectile/shotgun/pump/load_into_chamber()  //copy over the standard version, chambers itself after attacks
+	return 0
 
 /obj/item/weapon/gun/twohanded/projectile/shotgun/pump/combat
 	name = "combat shotgun"
@@ -73,27 +59,29 @@
 
 
 //PUMP SHOTGUN FLASHLIGHT CODE
-/obj/item/weapon/gun/twohanded/projectile/shotgun/pump/verb/toggle_light()
-	set name = "Toggle Flashlight"
-	set category = "Weapon"
+// Moved to guns/projectile.dm
 
-	if(haslight && !islighton) //Turns the light on
-		usr << "\blue You turn the flashlight on."
-		usr.SetLuminosity(gun_light)
-		islighton = 1
-	else if(haslight && islighton) //Turns the light off
-		usr << "\blue You turn the flashlight off."
-		usr.SetLuminosity(0)
-		islighton = 0
-	else if(!haslight) //Points out how stupid you are
-		usr << "\red You foolishly look at where the flashlight would be, if it was attached..."
-
-/obj/item/weapon/gun/twohanded/projectile/shotgun/pump/riot/pickup(mob/user)//Transfers the lum to the user when picked up
-	if(islighton)
-		SetLuminosity(0)
-		usr.SetLuminosity(gun_light)
-
-/obj/item/weapon/gun/twohanded/projectile/shotgun/pump/riot/dropped(mob/user)//Transfers the Lum back to the gun when dropped
-	if(islighton)
-		SetLuminosity(gun_light)
-		usr.SetLuminosity(0)
+///obj/item/weapon/gun/twohanded/projectile/shotgun/pump/verb/toggle_light()
+//	set name = "Toggle Flashlight"
+//	set category = "Weapon"
+//
+//	if(haslight && !islighton) //Turns the light on
+//		usr << "\blue You turn the flashlight on."
+//		usr.SetLuminosity(gun_light)
+//		islighton = 1
+//	else if(haslight && islighton) //Turns the light off
+//		usr << "\blue You turn the flashlight off."
+//		usr.SetLuminosity(0)
+//		islighton = 0
+//	else if(!haslight) //Points out how stupid you are
+//		usr << "\red You foolishly look at where the flashlight would be, if it was attached..."
+//
+///obj/item/weapon/gun/twohanded/projectile/shotgun/pump/riot/pickup(mob/user)//Transfers the lum to the user when picked up
+//	if(islighton)
+//		SetLuminosity(0)
+//		usr.SetLuminosity(gun_light)
+//
+///obj/item/weapon/gun/twohanded/projectile/shotgun/pump/riot/dropped(mob/user)//Transfers the Lum back to the gun when dropped
+//	if(islighton)
+//		SetLuminosity(gun_light)
+//		usr.SetLuminosity(0)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -86,7 +86,10 @@
 			if(!istype(A, /mob/living))
 				loc = A.loc
 				return 0// nope.avi
-
+			if(get_adj_simple(firer,A) && A.loc != get_step(firer,firer.dir))
+				bumped = 0
+				permutated.Add(A)
+				return 0
 			//Lower accurancy/longer range tradeoff. Distance matters a lot here, so at
 			// close distance, actually RAISE the chance to hit.
 			var/distance = get_dist(starting,loc)
@@ -96,8 +99,7 @@
 				if (daddy.target && original in daddy.target) //As opposed to no-delay pew pew
 					miss_modifier += -30
 			def_zone = get_zone_with_miss_chance(def_zone, M, -30 + 8*distance)
-
-			if(!def_zone || (get_adj_simple(firer,A) && A.loc != get_step(firer,firer.dir)))
+			if(!def_zone)
 				visible_message("\blue \The [src] misses [M] narrowly!")
 				forcedodge = -1
 			else
@@ -112,16 +114,15 @@
 				else
 					M.attack_log += "\[[time_stamp()]\] <b>UNKNOWN SUBJECT (No longer exists)</b> shot <b>[M]/[M.ckey]</b> with a <b>[src]</b>"
 					msg_admin_attack("UNKNOWN shot [M] ([M.ckey]) with a [src] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[firer.x];Y=[firer.y];Z=[firer.z]'>JMP</a>)") //BS12 EDIT ALG
-
 		if(A)
 			if (!forcedodge)
 				forcedodge = A.bullet_act(src, def_zone) // searches for return value
 			if(forcedodge == -1) // the bullet passes through a dense object!
 				bumped = 0 // reset bumped variable!
-				if(istype(A, /turf))
-					loc = A
-				else
-					loc = A.loc
+//				if(istype(A, /turf))
+//					loc = A
+//				else
+//					loc = A.loc
 				permutated.Add(A)
 				return 0
 			if(istype(A,/turf))

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -97,7 +97,7 @@
 					miss_modifier += -30
 			def_zone = get_zone_with_miss_chance(def_zone, M, -30 + 8*distance)
 
-			if(!def_zone)
+			if(!def_zone || (get_adj_simple(firer,A) && A.loc != get_step(firer,firer.dir)))
 				visible_message("\blue \The [src] misses [M] narrowly!")
 				forcedodge = -1
 			else
@@ -203,3 +203,17 @@
 				M = locate() in get_step(src,target)
 				if(istype(M))
 					return 1
+
+//Abby -- Just check if they're 1 tile horizontal or vertical, no diagonals
+/proc/get_adj_simple(atom/Loc1 as turf|mob|obj,atom/Loc2 as turf|mob|obj)
+	var/dx = Loc1.x - Loc2.x
+	var/dy = Loc1.y - Loc2.y
+
+	if(dx == 0)
+		if(dy == -1 || dy == 1)
+			return 1
+	if(dy == 0)
+		if(dx == -1 || dx == 1)
+			return 1
+
+	return 0

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -39,7 +39,18 @@ should be listed in the changelog upon commit tho. Thanks. -->
 
 
 
-<!-- DO NOT REMOVE OR MOVE THIS COMMENT! THIS MUST BE THE LAST NON-EMPTY LINE BEFORE THE LOGS #ADDTOCHANGELOGMARKER# -->
+<!-- DO NOT REMOVE OR MOVE THIS COMMENT! THIS MUST BE THE LAST NON-EMPTY LINE BEFORE THE LOGS #ADDTOCHANGELOGMARKER# -->
+
+<div class='commit sansserif'>
+	<h2 class='date'>15 May 2015</h2>
+	<h3 class='author'>Absynth updated:</h3>
+	<ul class='changes bgimages16'>
+		<li class='bugfix'>Flamethrower rewrite to no longer use atmos or gas processing</li>
+		<li class='tweak'>Projectiles no longer should hit friendly adjacents that are beside you (for firing lines)</li>
+		<li class='tweak'>Flashlights on guns work properly, more guns can have lights on em, and makes a fancy clicky noise. Toggle flashlight moved to Objects tab</li>
+		<li class='tweak'>Flares and flashlights can no longer be put in your pockets</li>
+	</ul>
+</div>
 
 <div class='commit sansserif'>
 	<h2 class='date'>14 May 2015</h2>


### PR DESCRIPTION
Some tweaks to the projectile and guns code in order to a) fix flashlights so they don't break all your light sources, and b) a tweak so that shooting not-exactly-horizontal should no longer hit someone standing next to you. It still hits people in front of you normally. Also fixes some other small bugs with projectiles, like being able to reload any item into an L6 SAW.

Has all been tested on local.
